### PR TITLE
Completely comment out hook_ENTITY_TYPE_load() - it has the wrong arguments

### DIFF
--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -132,8 +132,8 @@ function webform_civicrm_webform_autocomplete_options_alter(&$results, $node, $c
  *
  * @param array $nodes
  */
+/*
 function webform_civicrm_node_load($nodes, $types) {
-  /*
   $db = db_query('SELECT * FROM {webform_civicrm_forms} WHERE nid IN(:nids)', array(':nids' => array_keys($nodes)));
   foreach ($db as $settings) {
     $node = &$nodes[$settings->nid];
@@ -152,8 +152,8 @@ function webform_civicrm_node_load($nodes, $types) {
       }
     }
   }
-  */
 }
+*/
 
 /**
  * Implements hook_node_insert().


### PR DESCRIPTION
When cron runs, we end up with an `ArgumentCountError` because `hook_ENTITY_TYPE_load()` is being called and `webform_civicrm_node_load()` has the wrong arguments for that hook:

```
[22-Sep-2018 08:15:50 America/Chicago] ArgumentCountError: Too few arguments to function webform_civicrm_node_load(), 1 passed in /srv/bindings/4bec3916193b49feb397c21c4cb908af/code/web/core/lib/Drupal/Core/Entity/EntityStorageBase.php on line 306 and exactly 2 expected in /srv/bindings/4bec3916193b49feb397c21c4cb908af/code/web/modules/contrib/webform_civicrm/webform_civicrm.module on line 135 #0 /srv/bindings/4bec3916193b49feb397c21c4cb908af/code/web/core/lib/Drupal/Core/Entity/EntityStorageBase.php(306): webform_civicrm_node_load(Array)
#1 /srv/bindings/4bec3916193b49feb397c21c4cb908af/code/web/core/lib/Drupal/Core/Entity/EntityStorageBase.php(249): Drupal\Core\Entity\EntityStorageBase->postLoad(Array)
#2 /srv/bindings/4bec3916193b49feb397c21c4cb908af/code/web/core/modules/node/src/Plugin/Search/NodeSearch.php(451): Drupal\Core\Entity\EntityStorageBase->loadMultiple(Array)
#3 /srv/bindings/4bec3916193b49feb397c21c4cb908af/code/web/core/modules/search/search.module(203): Drupal\node\Plugin\Search\NodeSearch->updateIndex()
#4 [internal function]: search_cron()
#5 /srv/bindings/4bec3916193b49feb397c21c4cb908af/code/web/core/lib/Drupal/Core/Extension/ModuleHandler.php(391): call_user_func_array('search_cron', Array)
#6 /srv/bindings/4bec3916193b49feb397c21c4cb908af/code/web/core/lib/Drupal/Core/Cron.php(235): Drupal\Core\Extension\ModuleHandler->invoke('search', 'cron')
#7 /srv/bindings/4bec3916193b49feb397c21c4cb908af/code/web/core/lib/Drupal/Core/Cron.php(133): Drupal\Core\Cron->invokeCronHandlers()
#8 /srv/bindings/4bec3916193b49feb397c21c4cb908af/code/web/core/lib/Drupal/Core/ProxyClass/Cron.php(75): Drupal\Core\Cron->run()
#9 /srv/bindings/4bec3916193b49feb397c21c4cb908af/code/web/core/modules/automated_cron/src/EventSubscriber/AutomatedCron.php(65): Drupal\Core\ProxyClass\Cron->run()
```

Since the body of the function is commented out, this PR just comments out the whole thing, including the declaration.