### PR TITLE
Comment out hook_requirements()

### DIFF
--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -8,6 +8,7 @@
 /**
  * Implements hook_requirements().
  */
+/*
 function webform_civicrm_requirements($phase) {
   $requirements = array();
 
@@ -34,6 +35,7 @@ function webform_civicrm_requirements($phase) {
 
   return $requirements;
 }
+*/
 
 /**
  * Implements hook_schema().


### PR DESCRIPTION
Breaks the status report and other admin pages which trigger Drupal to check requirements